### PR TITLE
Add more details to the installation.mdx page

### DIFF
--- a/pages/getting-started/installation.mdx
+++ b/pages/getting-started/installation.mdx
@@ -15,15 +15,33 @@ You can buy a license on our [Craftable PRO website](https://craftable.pro#prici
 After obtaining a valid [Craftable PRO license](https://craftable.pro#pricing) you need to add our private repository to your composer.json:
 
 ```bash copy
-composer config repositories.craftable-pro composer https://packages.craftable.pro/
+composer config repositories.craftable-pro composer https://packages.craftable.pro
 ```
 
 ### Add the package
 
-Require the package with composer. You will be asked for username and password during the installation. **Use your email address as the username and the license key, you received after purchasing the license, as the password.** Alternatively you can create local or global `auth.json` file with your credentials. You can find more information about this in the [Composer documentation](https://getcomposer.org/doc/articles/authentication-for-private-packages.md#authentication-in-auth-json-per-project).
+Require the package with composer. You will be asked for username and password during the installation. **Use your email address as the username and the license key, you received after purchasing the license, as the password.**
+To avoid manually typing these credentials, you may create a [Composer auth.json file](https://getcomposer.org/doc/articles/authentication-for-private-packages.md#authentication-in-auth-json-per-project) while using your [license key](https://craftable.pro#pricing) in place of your password:
 
 ```bash copy
-composer require brackets/craftable-pro
+composer config http-basic.packages.craftable.pro your-account-email@your-domain.com your-license-key
+```
+After running the command above, an `auth.json` file will be present in the same folder as the projects' `composer.json` file, like so:
+```json
+{
+    "http-basic": {
+        "packages.craftable.pro": {
+            "username": "your-account-email@your-domain.com",
+            "password": "your-license-key"
+        }
+    }
+}
+```
+
+With the configuration above in place, you'll be able to install Craftable PRO into your project using this command:
+
+```bash copy
+composer require "brackets/craftable-pro:^2.0"
 ```
 
 ### Install the package


### PR DESCRIPTION
This PR adds more details to the installation page. The main 2 points are:  

1. Instructions on how to create the `auth.js` file and how it should look like
2. Specifying the package version when running the `composer require` command.

When I tried to just run `composer require brackets/craftable-pro` it failed, saying it could not be downloaded. At first glance I thought it was a problem with my authentication strategy, however, after inspecting, I see that it tried to install a different version, `dev-feat/ziggy2`:
![image](https://github.com/BRACKETS-by-TRIAD/craftable-pro-docs/assets/1384775/d1f53a11-e97f-49fa-922c-ff924b71a38b)

Specifying a version compatible with 2.0 resolves this problem.